### PR TITLE
Add user (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea
 /target
+/...
 Cargo.lock
+local.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,28 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# web framework
 rocket = "0.4.4"
+rocket_contrib = { version = "0.4.5", features = ["json"]}
+
+# ORM
+diesel = { version = "1.4.3", features = ["postgres", "r2d2"] }
+dotenv = "0.9.0"
+lazy_static = "1.4.0"
+
+# password hashing
+pwhash = "0.3"
+
+# jwt
+jsonwebtoken = "5"
+serde = {version = "1.0", features = ["derive"] }
+
+# random
+rand = "0.7"
+
+# mock
+mocktopus = "0.7.0"
+
+# log
+log = "0.4.0"
+env_logger = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 A project meant to help Othello Organisation Tournament to organise tournaments without too much dependencies on other people.
 
 To know more, please contact Samuel (samuelhenrykurniawan@yahoo.com)
+
+How to install:
+1) Install postgre sql
+2) Install rust
+3) Install rocket
+4) Install diesel

--- a/diesel.toml
+++ b/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/env.env
+++ b/env.env
@@ -1,0 +1,6 @@
+export DATABASE_URL=
+export SUPERUSER_ID=
+export SUPERUSER_DISPLAY_NAME=
+export SUPERUSER_PASS=
+export JWT_SECRET=
+export RUST_LOG=info

--- a/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/2020-03-11-171022_create_users/down.sql
+++ b/migrations/2020-03-11-171022_create_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE users

--- a/migrations/2020-03-11-171022_create_users/up.sql
+++ b/migrations/2020-03-11-171022_create_users/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR UNIQUE NOT NULL,
+    display_name VARCHAR NOT NULL,
+    hashed_password VARCHAR NOT NULL,
+    role VARCHAR NOT NULL
+);

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,0 +1,491 @@
+use std::collections::HashMap;
+
+use rocket::http::Cookies;
+use diesel::prelude::*;
+
+use super::database_models::User;
+use super::properties::UserRole;
+use super::utils::{JWTMediator, hash, verify};
+
+pub struct Account {
+    user: User
+}
+
+impl Account {
+    pub fn has_superuser_access(&self) -> bool {
+        match self.user.get_role() {
+            UserRole::Superuser => true,
+            UserRole::Admin => false,
+            _ => false
+        }
+    }
+
+    pub fn has_admin_access(&self) -> bool {
+        match self.user.get_role() {
+            UserRole::Superuser => true,
+            UserRole::Admin => true,
+            _ => false
+        }
+    }
+
+    pub fn create_new_admin(&self, username: &String, display_name: &String,
+                            hashed_password: &String, connection: &PgConnection)
+                            -> Result<(), String> {
+        if !self.has_superuser_access() {
+            return Err(String::from("Only superuser can create new admin account_test."));
+        }
+        User::create(username, display_name, hashed_password, UserRole::Admin, connection)
+    }
+
+    pub fn get_username(&self) -> String {
+        self.user.username.clone()
+    }
+
+    pub fn update(&mut self, display_name: Option<&String>, password: Option<&String>,
+                  connection: &PgConnection) -> Result<(), String> {
+        if let Some(updated_display_name) = display_name {
+            self.user.display_name = updated_display_name.clone();
+        }
+        if let Some(updated_password) = password {
+            self.user.hashed_password = hash(updated_password);
+        }
+        self.user.update(connection)
+    }
+
+    pub fn generate_meta(&self) -> HashMap<String, String> {
+        let mut meta: HashMap<String, String> = HashMap::new();
+        meta.insert(String::from("username"), self.user.username.clone());
+        meta.insert(String::from("display_name"), self.user.display_name.clone());
+        meta.insert(String::from("role"), self.user.get_role().to_string());
+        meta
+    }
+
+    pub fn generate_jwt(&self) -> Result<String, String> {
+        let username = self.get_username();
+        JWTMediator::generate_jwt_from_username(&username)
+    }
+}
+
+impl Account {
+    pub fn login_from_cookies(cookies: Cookies, connection: &PgConnection) -> Result<Account, String> {
+        let cookies_jwt = cookies.get("jwt").map(|c| c.value()).unwrap_or("");
+        let jwt = String::from(cookies_jwt);
+        Account::login_from_jwt(&jwt, connection)
+    }
+
+    pub fn login_from_jwt(jwt: &String, connection: &PgConnection) -> Result<Account, String> {
+        let username = match JWTMediator::get_username_from_jwt(jwt) {
+            Ok(username) => username,
+            Err(_) => return Err(String::from("Login expired."))
+        };
+
+        let user = match User::get(&username, connection) {
+            Ok(user) => user,
+            Err(_) => return Err(String::from("Requester user not found."))
+        };
+        Account::get_account_from_user(user)
+    }
+
+    pub fn login_from_password(username: &String, password: &String, connection: &PgConnection)
+                               -> Result<Account, String> {
+        let user = match User::get(&username, connection) {
+            Ok(user) => user,
+            Err(_) => return Err(String::from("Username not found."))
+        };
+
+        let is_password_correct = verify(password, &user.hashed_password);
+        if !is_password_correct {
+            return Err(String::from("Incorrect password."));
+        }
+        Account::get_account_from_user(user)
+    }
+
+    pub fn get(username: &String, connection: &PgConnection) -> Result<Account, String> {
+        let user = match User::get(&username, connection) {
+            Ok(user) => user,
+            Err(_) => return Err(String::from("Username not found."))
+        };
+        Account::get_account_from_user(user)
+    }
+
+    fn get_account_from_user(user: User) -> Result<Account, String> {
+        match user.get_role() {
+            UserRole::Superuser => Ok(Account { user }),
+            UserRole::Admin => Ok(Account { user }),
+            _ => Err(String::from("Something is wrong, please contact admin."))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod test_login_from_password {
+        use crate::account::Account;
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_superuser_login() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Superuser,
+                &test_connection,
+            );
+
+            assert_eq!(result.is_ok(), true);
+            let account = Account::login_from_password(
+                &username, &password, &test_connection
+            ).unwrap();
+            assert_eq!(account.has_superuser_access(), true);
+            assert_eq!(account.has_admin_access(), true);
+            assert_eq!(account.get_username(), username);
+        }
+
+        #[test]
+        fn test_admin_login() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Admin,
+                &test_connection,
+            );
+
+            assert_eq!(result.is_ok(), true);
+            let account = Account::login_from_password(
+                &username, &password, &test_connection
+            ).unwrap();
+            assert_eq!(account.has_superuser_access(), false);
+            assert_eq!(account.has_admin_access(), true);
+            assert_eq!(account.get_username(), username);
+        }
+
+        #[test]
+        fn test_login_incorrect_username() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Superuser,
+                &test_connection,
+            );
+
+            assert_eq!(result.is_ok(), true);
+            let login_result = Account::login_from_password(
+                &display_name, &password, &test_connection
+            );
+            assert_eq!(login_result.is_err(), true);
+        }
+
+        #[test]
+        fn test_login_incorrect_password() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Superuser,
+                &test_connection,
+            );
+
+            assert_eq!(result.is_ok(), true);
+            let login_result = Account::login_from_password(
+                &username, &hashed_password, &test_connection
+            );
+            assert_eq!(login_result.is_err(), true);
+        }
+    }
+
+    mod test_login_from_jwt {
+        use crate::account::Account;
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_superuser_login() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Superuser,
+                &test_connection,
+            );
+            assert_eq!(result.is_ok(), true);
+            let jwt = utils::JWTMediator::generate_jwt_from_username(&username).unwrap();
+
+            let account = Account::login_from_jwt(
+                &jwt, &test_connection
+            ).unwrap();
+            assert_eq!(account.has_superuser_access(), true);
+            assert_eq!(account.has_admin_access(), true);
+            assert_eq!(account.get_username(), username);
+        }
+
+        #[test]
+        fn test_admin_login() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Admin,
+                &test_connection,
+            );
+            assert_eq!(result.is_ok(), true);
+            let jwt = utils::JWTMediator::generate_jwt_from_username(&username).unwrap();
+
+            let account = Account::login_from_jwt(
+                &jwt, &test_connection
+            ).unwrap();
+            assert_eq!(account.has_superuser_access(), false);
+            assert_eq!(account.has_admin_access(), true);
+            assert_eq!(account.get_username(), username);
+        }
+
+        #[test]
+        fn test_login_incorrect_username() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+
+            let jwt = utils::JWTMediator::generate_jwt_from_username(&username).unwrap();
+            let login_result = Account::login_from_jwt(&jwt, &test_connection);
+            assert_eq!(login_result.is_err(), true);
+        }
+
+        #[test]
+        fn test_login_random_jwt() {
+            let test_connection = utils::get_test_connection();
+            let jwt = utils::generate_random_string(20);
+            let login_result = Account::login_from_jwt(
+                &jwt, &test_connection
+            );
+            assert_eq!(login_result.is_err(), true);
+        }
+    }
+
+    mod test_admin_creation {
+        use crate::account::Account;
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_admin_create_admin() {
+            let test_connection = utils::get_test_connection();
+
+            let admin_username = utils::generate_random_string(20);
+            let admin_display_name = utils::generate_random_string(20);
+            let admin_password = utils::generate_random_string(30);
+            let admin_hashed_password = utils::hash(&admin_password);
+            let _ = User::create(
+                &admin_username,
+                &admin_display_name,
+                &admin_hashed_password,
+                UserRole::Admin,
+                &test_connection
+            );
+            let user_admin = User::get(&admin_username, &test_connection).unwrap();
+            let account = Account{user: user_admin};
+
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+            let result = account.create_new_admin(
+                &username, &display_name, &hashed_password, &test_connection
+            );
+            assert_eq!(result.is_err(), true);
+        }
+
+        #[test]
+        fn test_superuser_create_admin() {
+            let test_connection = utils::get_test_connection();
+
+            let admin_username = utils::generate_random_string(20);
+            let admin_display_name = utils::generate_random_string(20);
+            let admin_password = utils::generate_random_string(30);
+            let admin_hashed_password = utils::hash(&admin_password);
+            let _ = User::create(
+                &admin_username,
+                &admin_display_name,
+                &admin_hashed_password,
+                UserRole::Superuser,
+                &test_connection
+            );
+            let user_admin = User::get(&admin_username, &test_connection).unwrap();
+            let account = Account{user: user_admin};
+
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+            let result = account.create_new_admin(
+                &username, &display_name, &hashed_password, &test_connection
+            );
+            assert_eq!(result.is_ok(), true);
+        }
+    }
+
+    mod test_update {
+        use crate::account::Account;
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_update_display_name() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+            let _ = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Admin,
+                &test_connection
+            );
+            let user = User::get(&username, &test_connection).unwrap();
+            let mut account = Account{user};
+            let updated_display_name = utils::generate_random_string(20);
+
+            let result = account.update(
+                Option::from(&updated_display_name),
+                Option::None,
+                &test_connection
+            );
+            assert_eq!(result.is_ok(), true);
+
+            let updated_user = User::get(&username, &test_connection).unwrap();
+            assert_eq!(updated_user.display_name, updated_display_name);
+        }
+
+        #[test]
+        fn test_update_password() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+            let _ = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Admin,
+                &test_connection
+            );
+
+            let user = User::get(&username, &test_connection).unwrap();
+            let mut account = Account{user};
+            let updated_password = utils::generate_random_string(20);
+            let result = account.update(
+                Option::None,
+                Option::from(&updated_password),
+                &test_connection
+            );
+            assert_eq!(result.is_ok(), true);
+
+            let updated_user = User::get(&username, &test_connection).unwrap();
+            assert_eq!(utils::verify(&updated_password, &updated_user.hashed_password), true);
+        }
+
+        #[test]
+        fn test_update_both() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+            let _ = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Admin,
+                &test_connection
+            );
+
+            let user = User::get(&username, &test_connection).unwrap();
+            let mut account = Account{user};
+            let updated_display_name = utils::generate_random_string(20);
+            let updated_password = utils::generate_random_string(20);
+            let result = account.update(
+                Option::from(&updated_display_name),
+                Option::from(&updated_password),
+                &test_connection
+            );
+            assert_eq!(result.is_ok(), true);
+
+            let updated_user = User::get(&username, &test_connection).unwrap();
+            assert_eq!(updated_user.display_name, updated_display_name);
+            assert_eq!(utils::verify(&updated_password, &updated_user.hashed_password), true);
+        }
+
+        #[test]
+        fn test_update_none() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+            let _ = User::create(
+                &username,
+                &display_name,
+                &hashed_password,
+                UserRole::Admin,
+                &test_connection
+            );
+
+            let user = User::get(&username, &test_connection).unwrap();
+            let mut account = Account{user};
+            let result = account.update(
+                Option::None,
+                Option::None,
+                &test_connection
+            );
+            assert_eq!(result.is_ok(), true);
+
+            let updated_user = User::get(&username, &test_connection).unwrap();
+            assert_eq!(updated_user.display_name, display_name);
+            assert_eq!(utils::verify(&password, &updated_user.hashed_password), true);
+        }
+    }
+}

--- a/src/database_models/mod.rs
+++ b/src/database_models/mod.rs
@@ -1,0 +1,3 @@
+mod user_models;
+
+pub use user_models::User;

--- a/src/database_models/user_models.rs
+++ b/src/database_models/user_models.rs
@@ -1,0 +1,198 @@
+use diesel::prelude::*;
+
+use super::super::schema::users;
+use super::super::properties::UserRole;
+
+#[derive(AsChangeset, PartialEq, Debug, Queryable)]
+pub struct User {
+    id: i32,
+    pub username: String,
+    pub display_name: String,
+    pub hashed_password: String,
+    role: String,
+}
+
+#[derive(Insertable)]
+#[table_name = "users"]
+struct NewUser<'a> {
+    pub username: &'a String,
+    pub display_name: &'a String,
+    pub hashed_password: &'a String,
+    pub role: &'a String,
+}
+
+impl User {
+    pub fn create(username: &String, display_name: &String, hashed_password: &String, role: UserRole,
+                  connection: &PgConnection) -> Result<(), String> {
+        if User::is_username_exists(&username, connection) {
+            return Err(String::from("Username exists."));
+        }
+        let new_user = NewUser {
+            username,
+            display_name,
+            hashed_password,
+            role: &role.to_string(),
+        };
+        User::insert_to_database(new_user, connection)
+    }
+
+    fn is_username_exists(username: &String, connection: &PgConnection) -> bool {
+        if let Ok(_) = User::get(username, connection) {
+            return true;
+        }
+        false
+    }
+
+    fn insert_to_database(new_user: NewUser, connection: &PgConnection) -> Result<(), String> {
+        let username = new_user.username.clone();
+        let display_name = new_user.display_name.clone();
+        let role = new_user.role.clone();
+
+        let result = diesel::insert_into(users::table)
+            .values(new_user)
+            .execute(connection);
+        match result {
+            Err(_) => Err(String::from("Cannot create new user.")),
+            _ => {
+                info!("User {} ({}) is created as {}", username, display_name, role);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn get(username: &String, connection: &PgConnection) -> Result<User, String> {
+        let result = users::table
+            .filter(users::username.eq(&username))
+            .load::<User>(connection);
+
+        if let Err(_) = result {
+            return Err(String::from("Failed connecting to database."));
+        }
+
+        let mut filtered_users = result.unwrap();
+        if let Some(user) = filtered_users.pop() {
+            return Ok(user);
+        }
+        Err(String::from("User not found."))
+    }
+
+    pub fn get_role(&self) -> UserRole {
+        return UserRole::from_string(self.role.clone());
+    }
+
+    pub fn update(&self, connection: &PgConnection) -> Result<(), String> {
+        let result = diesel::update(users::table.find(self.id))
+            .set(self)
+            .execute(connection);
+        match result {
+            Err(_) => Err(String::from("User failed to update")),
+            _ => {
+                info!("User {} ({}) is updated", &self.username, &self.display_name);
+                Ok(())
+            }
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    mod test_user_creation {
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_create_new_user() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let result = User::create(
+                &username, &display_name, &hashed_password, UserRole::Superuser, &test_connection
+            );
+            assert_eq!(result.is_ok(), true);
+        }
+
+        #[test]
+        fn test_create_user_with_duplicate_username() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let second_display_name = utils::generate_random_string(20);
+            let second_password = utils::generate_random_string(30);
+            let second_hashed_password = utils::hash(&second_password);
+
+            let _ = User::create(&username, &display_name, &hashed_password, UserRole::Superuser, &test_connection);
+            let result = User::create(
+                &username, &second_display_name, &second_hashed_password, UserRole::Admin, &test_connection
+            );
+            assert_eq!(result.is_err(), true);
+        }
+    }
+
+    mod test_user_retrieval {
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_get_user() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let _ = User::create(&username, &display_name, &hashed_password, UserRole::Superuser, &test_connection);
+
+            let user = User::get(&username, &test_connection).unwrap();
+            assert_eq!(user.username, username);
+            assert_eq!(user.display_name, display_name);
+            assert_eq!(user.hashed_password, hashed_password);
+        }
+
+        #[test]
+        fn test_get_user_not_found() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+
+            let result = User::get(&username, &test_connection);
+            assert_eq!(result.is_err(), true);
+        }
+    }
+
+    mod test_user_update {
+        use crate::database_models::User;
+        use crate::properties::UserRole;
+        use crate::utils;
+
+        #[test]
+        fn test_update_user() {
+            let test_connection = utils::get_test_connection();
+            let username = utils::generate_random_string(20);
+            let display_name = utils::generate_random_string(20);
+            let password = utils::generate_random_string(30);
+            let hashed_password = utils::hash(&password);
+
+            let _ = User::create(&username, &display_name, &hashed_password, UserRole::Superuser, &test_connection);
+
+            let mut user = User::get(&username, &test_connection).unwrap();
+
+            let updated_display_name = utils::generate_random_string(20);
+            user.display_name = updated_display_name.clone();
+            let _ = user.update(&test_connection);
+
+            let updated_user = User::get(&username, &test_connection).unwrap();
+            assert_ne!(updated_user.display_name, display_name);
+            assert_eq!(updated_user.display_name, updated_display_name);
+            assert_eq!(updated_user.username, username);
+            assert_eq!(updated_user.hashed_password, hashed_password);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,54 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+#[macro_use]
+extern crate rocket;
+
+#[macro_use]
+extern crate rocket_contrib;
+
+#[macro_use]
+extern crate diesel;
+
+#[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
+extern crate log;
+
+extern crate mocktopus;
+use std::env;
+
+pub mod account;
+pub mod database_models;
+pub mod properties;
+pub mod schema;
+pub mod routes;
+pub mod utils;
+
+fn create_default_superuser() {
+    let connection = utils::get_pooled_connection();
+    let username = env::var("SUPERUSER_ID").unwrap();
+    let display_name =  env::var("SUPERUSER_DISPLAY_NAME").unwrap();
+    let password =  env::var("SUPERUSER_PASS").unwrap();
+    let hashed_password = utils::hash(&password);
+    let _ = database_models::User::create(
+        &username, &display_name, &hashed_password, properties::UserRole::Superuser, &connection
+    );
+}
+
 fn main() {
-    println!("Hello, world!");
+    env_logger::init();
+    info!("Starting the program");
+    create_default_superuser();
+
+    rocket::ignite()
+        .mount("/user", routes![
+            routes::user_routes::get_user,
+            routes::user_routes::create_user,
+            routes::user_routes::update_user,
+        ])
+        .mount("/", routes![
+            routes::general_routes::login,
+            routes::general_routes::get_current_user_profile,
+        ])
+        .launch();
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,0 +1,56 @@
+#[derive(Debug, PartialEq)]
+pub enum UserRole {
+    Superuser,
+    Admin,
+    Visitor,
+}
+
+impl UserRole {
+    pub fn from_string(role: String) -> UserRole {
+        match role.as_str() {
+            "superuser" => UserRole::Superuser,
+            "admin" => UserRole::Admin,
+            _ => UserRole::Visitor,
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        match self {
+            UserRole::Superuser => String::from("superuser"),
+            UserRole::Admin => String::from("admin"),
+            _ => String::from("visitor"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod test_user_role {
+        use crate::properties::UserRole;
+
+        #[test]
+        fn test_from_string() {
+            assert_eq!(UserRole::from_string(String::from("superuser")), UserRole::Superuser);
+            assert_eq!(UserRole::from_string(String::from("admin")), UserRole::Admin);
+            assert_eq!(UserRole::from_string(String::from("visitor")), UserRole::Visitor);
+            assert_eq!(UserRole::from_string(String::from("")), UserRole::Visitor);
+            assert_eq!(UserRole::from_string(String::from("random junk")), UserRole::Visitor);
+        }
+
+        #[test]
+        fn test_to_string() {
+            assert_eq!(UserRole::Superuser.to_string(), String::from("superuser"));
+            assert_eq!(UserRole::Admin.to_string(), String::from("admin"));
+            assert_eq!(UserRole::Visitor.to_string(), String::from("visitor"));
+        }
+
+        #[test]
+        fn test_from_and_to_string() {
+            assert_eq!(UserRole::from_string(String::from("superuser")).to_string(), String::from("superuser"));
+            assert_eq!(UserRole::from_string(String::from("admin")).to_string(), String::from("admin"));
+            assert_eq!(UserRole::from_string(String::from("visitor")).to_string(), String::from("visitor"));
+            assert_eq!(UserRole::from_string(String::from("junk string")).to_string(), String::from("visitor"));
+            assert_eq!(UserRole::from_string(String::from("")).to_string(), String::from("visitor"));
+        }
+    }
+}

--- a/src/routes/general_routes.rs
+++ b/src/routes/general_routes.rs
@@ -1,0 +1,41 @@
+use rocket::http::Cookies;
+use rocket_contrib::json::{JsonValue, Json};
+use serde::Deserialize;
+
+use super::response::create_response;
+use super::user_routes::get_user;
+use super::super::account::Account;
+use super::super::utils::get_pooled_connection;
+
+#[derive(Deserialize)]
+pub struct UserLoginRequest {
+    username: String,
+    password: String,
+}
+
+#[post("/login", data = "<request>")]
+pub fn login(request: Json<UserLoginRequest>) -> Json<JsonValue> {
+    let connection = get_pooled_connection();
+    let account = match Account::login_from_password(
+        &request.username, &request.password, &connection
+    ) {
+        Ok(account) => account,
+        Err(message) => return create_response(Err(message))
+    };
+
+    info!("{} is logged in.", account.get_username());
+    match account.generate_jwt() {
+        Ok(jwt) => create_response(Ok(json!({"jwt": jwt}))),
+        Err(message) => create_response(Err(message))
+    }
+}
+
+#[get("/profile")]
+pub fn get_current_user_profile(cookies: Cookies) -> Json<JsonValue> {
+    let connection = get_pooled_connection();
+    let username = match Account::login_from_cookies(cookies, &connection) {
+        Ok(account) => account.get_username(),
+        Err(message) => return create_response(Err(message))
+    };
+    get_user(username)
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,3 @@
+pub mod user_routes;
+pub mod general_routes;
+pub mod response;

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -1,0 +1,17 @@
+use rocket_contrib::json::{Json, JsonValue};
+
+pub fn create_response(process_result: Result<JsonValue, String>) -> Json<JsonValue> {
+    match process_result {
+        Ok(result) => Json(json!({
+            "success": result,
+            "error": ""
+        })),
+        Err(message) => {
+            error!("Failed request, {}", &message);
+            Json(json!({
+                "success": "",
+                "error": message
+            }))
+        }
+    }
+}

--- a/src/routes/user_routes.rs
+++ b/src/routes/user_routes.rs
@@ -1,0 +1,82 @@
+use rocket::http::Cookies;
+use rocket_contrib::json::{JsonValue, Json};
+use serde::Deserialize;
+
+use super::response::create_response;
+use super::super::account::Account;
+use super::super::utils::{get_pooled_connection, hash};
+
+#[derive(Deserialize)]
+pub struct UserCreationRequest {
+    username: String,
+    display_name: String,
+    password: String,
+}
+
+#[derive(Deserialize)]
+pub struct UserUpdateRequest {
+    display_name: Option<String>,
+    password: Option<String>
+}
+
+#[get("/<username>")]
+pub fn get_user(username: String) -> Json<JsonValue> {
+    let connection = get_pooled_connection();
+    match Account::get(&username, &connection) {
+        Ok(account) => create_response(Ok(json!(account.generate_meta()))),
+        Err(message) => create_response(Err(message))
+    }
+}
+
+#[post("/", data = "<request>")]
+pub fn create_user(cookies: Cookies, request: Json<UserCreationRequest>) -> Json<JsonValue> {
+    let connection = get_pooled_connection();
+    let account = match Account::login_from_cookies(cookies, &connection) {
+        Ok(account) => account,
+        Err(message) => return create_response(Err(message))
+    };
+
+    if !account.has_superuser_access() {
+        return create_response(Err(String::from(
+            "You are not authorized to create an admin account."))
+        )
+    }
+    let hashed_password = hash(&request.password);
+    match account.create_new_admin(
+        &request.username, &request.display_name, &hashed_password, &connection
+    ) {
+        Ok(()) => create_response(Ok(json!({"message": "User created"}))),
+        Err(message) => create_response(Err(message))
+    }
+}
+
+#[patch("/<username>", data = "<request>")]
+pub fn update_user(cookies: Cookies, username: String, request: Json<UserUpdateRequest>)
+    -> Json<JsonValue> {
+    let connection = get_pooled_connection();
+    let mut account = match Account::login_from_cookies(cookies, &connection) {
+        Ok(account) => account,
+        Err(message) => return create_response(Err(message))
+    };
+
+    if !(account.has_superuser_access() || account.get_username() == username) {
+        return create_response(Err(
+            String::from("You are not authorized to change other people profile."))
+        )
+    }
+
+    let display_name = match &request.display_name {
+        Some(name) => Option::from(name),
+        None => Option::None
+    };
+    let password = match &request.password {
+        Some(password) => Option::from(password),
+        None => Option::None
+    };
+
+    match account.update(display_name, password, &connection) {
+        Ok(()) => create_response(Ok(json!({"message": "User updated"}))),
+        Err(message) => create_response(Err(message))
+    }
+
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,9 @@
+table! {
+    users (id) {
+        id -> Int4,
+        username -> Varchar,
+        display_name -> Varchar,
+        hashed_password -> Varchar,
+        role -> Varchar,
+    }
+}

--- a/src/utils/database_connection.rs
+++ b/src/utils/database_connection.rs
@@ -1,0 +1,36 @@
+use diesel::pg::PgConnection;
+use diesel::r2d2::{Pool, PooledConnection, ConnectionManager};
+use diesel::prelude::*;
+use dotenv::dotenv;
+use std::env;
+
+type PostgresPool = Pool<ConnectionManager<PgConnection>>;
+pub type PostgresPooledConnection = PooledConnection<ConnectionManager<PgConnection>>;
+
+lazy_static! {
+    pub static ref POOL: PostgresPool = { init_pool() };
+}
+
+fn init_pool() -> PostgresPool {
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let manager = ConnectionManager::<PgConnection>::new(database_url);
+    Pool::builder()
+        .build(manager)
+        .expect("Failed to create pool.")
+}
+
+pub fn get_pooled_connection() -> PostgresPooledConnection {
+    let pool = POOL.clone();
+    let connection = pool.get().expect("Failed to get pooled connection");
+    connection
+}
+
+pub fn get_test_connection() -> PgConnection {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let connection = PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url));
+    connection.begin_test_transaction().unwrap();
+    connection
+}

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -1,0 +1,9 @@
+use mocktopus::macros::mockable;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[mockable]
+pub fn get_current_timestamp() -> u64 {
+    let start = SystemTime::now();
+    start.duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs()
+}

--- a/src/utils/hash.rs
+++ b/src/utils/hash.rs
@@ -1,0 +1,9 @@
+use pwhash::bcrypt;
+
+pub fn hash(string: &String) -> String {
+    bcrypt::hash(string).unwrap()
+}
+
+pub fn verify(string: &String, hashed_string: &String) -> bool {
+    bcrypt::verify(string, hashed_string)
+}

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,0 +1,92 @@
+use std::env;
+use serde::{Deserialize, Serialize};
+use jsonwebtoken::{encode, decode, Header, Validation};
+use jsonwebtoken::errors::{ErrorKind};
+
+use super::get_current_timestamp;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub exp: u64,
+    pub iss: String,
+    pub username: String
+}
+
+pub struct JWTMediator {}
+
+impl JWTMediator {
+
+    pub fn generate_jwt_from_username(username: &String) -> Result<String, String> {
+        let claims = JWTMediator::generate_claims(username);
+        let secret_key = env::var("JWT_SECRET").expect("JWT_SECRET must be set");
+        match encode(&Header::default(), &claims, secret_key.as_ref()) {
+            Ok(token) => Ok(token),
+            Err(_) => Err(String::from("Failed to generate token"))
+        }
+    }
+
+    fn generate_claims(username: &String) -> Claims {
+        Claims {
+            exp: 60 * 60 * 30 + get_current_timestamp(),
+            iss: JWTMediator::get_issuer(),
+            username: username.clone()
+        }
+    }
+
+    fn get_issuer() -> String {
+        String::from("Othello Storm System")
+    }
+
+    pub fn get_username_from_jwt(jwt: &String) -> Result<String, String> {
+        let secret_key = env::var("JWT_SECRET").expect("JWT_SECRET must be set");
+        let validation = Validation { iss: Some(JWTMediator::get_issuer()), ..Validation::default()};
+        let token_data = match decode::<Claims>(jwt, secret_key.as_ref(), &validation) {
+            Ok(t) => t,
+            Err(err) => return match *err.kind() {
+                ErrorKind::ExpiredSignature => Err(String::from("Token expired")),
+                _ => Err(String::from("Something is wrong"))
+            }
+        };
+        Ok(token_data.claims.username)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod test_get_generate_jwt {
+        use crate::utils::JWTMediator;
+        use crate::utils;
+        use mocktopus::mocking::{Mockable, MockResult};
+
+        #[test]
+        fn test_generate_jwt() {
+            let username = utils::generate_random_string(10);
+            let result = JWTMediator::generate_jwt_from_username(&username);
+            assert_eq!(result.is_ok(), true);
+        }
+
+        #[test]
+        fn test_generate_get_jwt() {
+            let username = utils::generate_random_string(10);
+            let jwt = JWTMediator::generate_jwt_from_username(&username).unwrap();
+            let username_claimed = JWTMediator::get_username_from_jwt(&jwt).unwrap();
+            assert_eq!(username, username_claimed);
+        }
+
+        #[test]
+        fn test_generate_get_jwt_error() {
+            let jwt = utils::generate_random_string(60);
+            let result = JWTMediator::get_username_from_jwt(&jwt);
+            assert_eq!(result.is_err(), true);
+        }
+
+        #[test]
+        fn test_expired_jwt() {
+            utils::get_current_timestamp.mock_safe(|| MockResult::Return(0));
+            let username = utils::generate_random_string(10);
+            let jwt = JWTMediator::generate_jwt_from_username(&username).unwrap();
+            let result = JWTMediator::get_username_from_jwt(&jwt);
+            assert_eq!(result.is_err(), true);
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,11 @@
+mod database_connection;
+mod datetime;
+mod hash;
+mod jwt;
+mod random;
+
+pub use database_connection::{get_pooled_connection, get_test_connection};
+pub use datetime::get_current_timestamp;
+pub use hash::{hash, verify};
+pub use jwt::JWTMediator;
+pub use random::{generate_random_number, generate_random_string};

--- a/src/utils/random.rs
+++ b/src/utils/random.rs
@@ -1,0 +1,13 @@
+extern crate rand;
+
+use rand::{thread_rng, Rng};
+use rand::distributions::Alphanumeric;
+
+pub fn generate_random_string(length: usize) -> String {
+    thread_rng().sample_iter(&Alphanumeric).take(length).collect()
+}
+
+pub fn generate_random_number() -> i32 {
+    let mut rng = thread_rng();
+    rng.gen::<i32>()
+}


### PR DESCRIPTION
* edit README.md and project setup

* temp commit

* implement UserRole enum and backbone for user

* add user signup

* Refactor and add user access control function

* refactor and add login

* add save function

* add install guidance

* Refactor user model

* abstract external services and add test create superuser

* add test create new admin

* Refactor and add test duplicated username

* add user update test

* refactor and renaming

* add user login test

* completed user model test

* move external services

* add jwt

* generate random username for tests and for dummy visitor account

* add visitor access

* abstract jwt related stuffs

* add access control for user editing

* Add admin and superuser access

* Add test jwt

* refactoring

* remove update display name

* use connection instead of service of user methods

* add access control test

* Refactor: use user_models as DTO and make jwt not dependent on user

* add accounts and incorporate logs

* add user routes

* refactor redundant account factory

* complete user related routes

Co-authored-by: Samuel Henry Kurniawan <kurniawans@seagroup.com>